### PR TITLE
Fix undefined calculate_ipv6_delegation_length()

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -32,6 +32,7 @@
 require_once('dyndns.class');
 require_once('unbound.inc');
 require_once('miniupnpd.inc');
+require_once('pfsense-utils.inc');
 
 function generate_ipv6_from_mac($mac)
 {


### PR DESCRIPTION
Error message "Fatal error: Call to undefined function calculate_ipv6_delegation_length() in /usr/local/etc/inc/services.inc on line 1060"
in
Services -> DHCPv6 -> Advertisements
Services -> DHCPv6 -> Relay
